### PR TITLE
Fix AnimatedGradient build error on motion className

### DIFF
--- a/components/AnimatedGradient.tsx
+++ b/components/AnimatedGradient.tsx
@@ -9,9 +9,10 @@ export function AnimatedGradient(){
         initial={{opacity: 0.3, scale: 0.9, x: -100, y: -100}}
         animate={{opacity: 0.6, scale: 1, x: 0, y: 0}}
         transition={{duration: 3, ease: "easeOut"}}
-        className="pointer-events-none blur-3xl"
       >
-        <div className="h-[60vh] w-[80vw] md:w-[60vw] rounded-full from-brand-400 via-violet-500 to-emerald-400 bg-gradient-to-tr opacity-20" />
+        <div className="pointer-events-none blur-3xl">
+          <div className="h-[60vh] w-[80vw] md:w-[60vw] rounded-full from-brand-400 via-violet-500 to-emerald-400 bg-gradient-to-tr opacity-20" />
+        </div>
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove `className` from `motion.div` to satisfy framer-motion types
- wrap gradient in a `div` with pointer events and blur classes

## Testing
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf556319e8832b91d79132a8b99b26