### PR TITLE
chore: add critters dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "clsx": "2.1.1",
+    "critters": "0.0.22",
     "framer-motion": "11.3.30",
     "lucide-react": "0.453.0",
     "next": "15.5.0",


### PR DESCRIPTION
## Summary
- add critters to dependencies for Next.js CSS optimization

## Testing
- `npm install critters@0.0.22 --save --registry=https://registry.npmmirror.com` *(fails: 403 Forbidden - GET https://registry.npmmirror.com/critters)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5859ab38832b9684dd6201eba138