### PR TITLE
Remove street quality criteria references

### DIFF
--- a/app/(site)/how-it-works/page.tsx
+++ b/app/(site)/how-it-works/page.tsx
@@ -10,9 +10,9 @@ export default function HowItWorksPage(){
         <div className="mt-8">
           <Steps steps={[
             {title: "Public perception & site selection", body: "Select representative streets and spaces via a diversity grid and local knowledge."},
-            {title: "Individual rating", body: "Residents score 20 images on 4 key criteria to establish baselines."},
-            {title: "Group rating & re-evaluation", body: "Small groups discuss, re-evaluate with all 12 criteria, and document rationales."},
-            {title: "Ranking exercise", body: "Rank 7 options with full criteria to reveal trade-offs and consensus."},
+            {title: "Individual rating", body: "Residents score images on key criteria to establish baselines."},
+            {title: "Group rating & re-evaluation", body: "Small groups discuss, re-evaluate, and document rationales."},
+            {title: "Ranking exercise", body: "Rank options to reveal trade-offs and consensus."},
             {title: "Results synthesis", body: "Surface agreement vs. disagreement, including shifts post‑dialogue."},
             {title: "Design briefing", body: "Translate insights into a design brief and before/after visuals."},
           ]} />

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -4,7 +4,6 @@ import VideoPlayer from "@/components/VideoPlayer";
 import Marquee from "@/components/Marquee";
 import FeatureCard from "@/components/FeatureCard";
 import Steps from "@/components/Steps";
-import { STREET_QUALITY_CRITERIA } from "@/lib/utils";
 
 export default function Page(){
   return (
@@ -27,7 +26,7 @@ export default function Page(){
               <Button href="/product" variant="ghost">Explore the product</Button>
             </div>
             <div className="mt-8 text-xs text-white/50 max-w-lg">
-              Backed by dialogue-based methods that increased agreement on inclusivity and accessibility after group discussion.
+              Backed by dialogue-based methods that increased agreement after group discussion.
             </div>
           </div>
           <div className="lg:col-span-6">
@@ -44,7 +43,7 @@ export default function Page(){
       <Section className="mt-16 md:mt-24">
         <div className="grid md:grid-cols-3 gap-4">
           <FeatureCard title="See what residents see">
-            Use image-based prompts of real streets to rapidly gather preferences across 12 street-quality criteria—from accessibility to aesthetics.
+            Use image-based prompts of real streets to rapidly gather preferences across key street-quality dimensions.
           </FeatureCard>
           <FeatureCard title="Facilitate consensus">
             Move from individual ratings to small-group dialogue and re-evaluation to surface agreements and disagreements.
@@ -58,36 +57,12 @@ export default function Page(){
       <Section className="mt-16 md:mt-24">
         <div className="grid md:grid-cols-12 gap-8 items-start">
           <div className="md:col-span-7">
-            <div className="card">
-              <h3 className="text-white text-lg font-semibold">12 criteria we measure</h3>
-              <ul className="mt-3 grid grid-cols-2 md:grid-cols-3 gap-2 text-sm text-white/80">
-                {STREET_QUALITY_CRITERIA.map(c => <li key={c} className="px-3 py-2 rounded-lg bg-white/5 border border-white/10">{c}</li>)}
-              </ul>
-            </div>
-          </div>
-          <div className="md:col-span-5">
-            <div className="card">
-              <h3 className="text-white text-lg font-semibold">Pilot snapshot</h3>
-              <ul className="mt-3 space-y-2 text-white/80 text-sm">
-                <li>100+ organizations reached for recruitment</li>
-                <li>28 residents consulted across diversity grid</li>
-                <li>20 street images rated; 7 images ranked using 12 criteria</li>
-                <li>Consensus strongest on aesthetics &amp; regeneration; weaker on inclusivity &amp; practicality</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </Section>
-
-      <Section className="mt-16 md:mt-24">
-        <div className="grid md:grid-cols-12 gap-8 items-start">
-          <div className="md:col-span-7">
             <h2 className="text-2xl font-semibold">How it works</h2>
             <p className="mt-3 text-white/80 max-w-2xl">A repeatable, mixed-methods workflow that captures authentic local knowledge and balances plural values.</p>
             <div className="mt-6">
               <Steps steps={[
                 {title: "Recruit & listen", body: "Partner with community organizations; recruit across a diversity grid and conduct interviews to gather context."},
-                {title: "Rate what matters", body: "Residents individually rate street images on 4 key criteria, then discuss and re-evaluate using all 12."},
+                {title: "Rate what matters", body: "Residents individually rate street images, then discuss and re-evaluate together."},
                 {title: "Rank & brief", body: "Convert agreement patterns into ranked options and a design brief, then show before/after concepts stakeholders can compare."}
               ]} />
             </div>

--- a/app/(site)/product/page.tsx
+++ b/app/(site)/product/page.tsx
@@ -6,7 +6,7 @@ export default function ProductPage(){
     <>
       <Section className="pt-12 md:pt-20">
         <h1 className="text-3xl md:text-5xl font-semibold tracking-tight">Product</h1>
-        <p className="mt-3 text-white/80 max-w-2xl">WeDesign+ is a research-informed platform that blends participatory workshops, image-based rating tools, and AI-assisted analysis to help cities design inclusive, practical, and beautiful public spaces.</p>
+        <p className="mt-3 text-white/80 max-w-2xl">WeDesign+ is a research-informed platform that blends participatory workshops, image-based rating tools, and AI-assisted analysis to help cities design better public spaces.</p>
       </Section>
 
       <Section className="mt-12 grid md:grid-cols-3 gap-4">
@@ -14,10 +14,10 @@ export default function ProductPage(){
           Reach 100+ organizations, recruit residents across a diversity grid, and capture interviews for context.
         </FeatureCard>
         <FeatureCard title="Rating & ranking engine">
-          Configure 12 criteria; collect individual ratings on 4 key criteria and group re-evaluations on all 12; rank 7 images.
+          Collect individual ratings on key criteria and facilitate group re-evaluations; rank images based on feedback.
         </FeatureCard>
         <FeatureCard title="Dialogue analytics">
-          See agreement and disagreement patterns; quantify the effect of discussion on inclusivity and accessibility.
+          See agreement and disagreement patterns; quantify the effect of discussion.
         </FeatureCard>
       </Section>
 

--- a/app/(site)/research/page.tsx
+++ b/app/(site)/research/page.tsx
@@ -5,7 +5,7 @@ export default function ResearchPage(){
     <>
       <Section className="pt-12 md:pt-20 prose prose-invert max-w-none">
         <h1>Research & Ethics</h1>
-        <p>WeDesign+ stands on established research in citizen engagement and participatory methods. Our workflow is designed to increase agreement on inclusivity and accessibility through structured group dialogue while keeping plural values visible.</p>
+        <p>WeDesign+ stands on established research in citizen engagement and participatory methods. Our workflow is designed to increase agreement through structured group dialogue while keeping plural values visible.</p>
         <h2>Selected references</h2>
         <ul>
           <li>DataIntelo – Citizen Engagement Software Market (industry outlook)</li>
@@ -15,7 +15,7 @@ export default function ResearchPage(){
         </ul>
         <h2>Ethical safeguards</h2>
         <ul>
-          <li>Pluralistic alignment techniques; equal-weight ratings across criteria</li>
+          <li>Pluralistic alignment techniques; equal-weight ratings</li>
           <li>Local place understanding in training data</li>
           <li>Transparent small‑group consultations; auditability of shifts pre/post discussion</li>
         </ul>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,12 +10,6 @@ export const ORGS = [
   "Congolese Community Center of Montreal"
 ];
 
-export const STREET_QUALITY_CRITERIA = [
-  "Accessibility","Invitingness","Comfort","Regeneration","Aesthetics",
-  "Practicality","Maintenance","Inclusivity","Dynamism","Representation",
-  "Oppression","Security"
-];
-
 export const SITE_NAME = "WeDesign+";
 export const DOMAIN = "wedesign.one";
 export const TAGLINE = "Designing inclusive public spaces through participatory AI";


### PR DESCRIPTION
## Summary
- Simplify utilities by removing the `STREET_QUALITY_CRITERIA` array.
- Streamline home, product, and research pages to eliminate references to 12 street-quality criteria and related terminology.
- Clarify workflow descriptions without numeric criteria references.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found; dependency install blocked by 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf62cc7b04832baaba4c0ec22cd00b