### PR TITLE
Remove team titles and add image placeholders

### DIFF
--- a/app/(site)/team/page.tsx
+++ b/app/(site)/team/page.tsx
@@ -1,9 +1,15 @@
+import Image from "next/image";
 import Section from "@/components/Section";
 
-const TEAM = [
-  {name: "Rashid Mushkani", role: "CEO"},
-  {name: "Hugo Berard", role: "CTO"},
-  {name: "Shin Koseki", role: "CFO"},
+interface TeamMember {
+  name: string;
+  image: string;
+}
+
+const TEAM: TeamMember[] = [
+  { name: "Rashid Mushkani", image: "/rashid.png" },
+  { name: "Hugo Berard", image: "/hugo.png" },
+  { name: "Shin Koseki", image: "/shin.png" },
 ];
 
 export default function TeamPage(){
@@ -11,13 +17,20 @@ export default function TeamPage(){
     <>
       <Section className="pt-12 md:pt-20">
         <h1 className="text-3xl md:text-5xl font-semibold tracking-tight">Team</h1>
-        <p className="mt-3 text-white/80">We are urbanists and technologists working at the intersection of AI and public space.</p>
+        <p className="mt-3 text-white/80">
+          We are urbanists and technologists working at the intersection of AI and public space.
+        </p>
         <div className="mt-8 grid md:grid-cols-3 gap-4">
-          {TEAM.map(m => (
+          {TEAM.map((m) => (
             <div key={m.name} className="card">
-              <div className="h-24 w-24 rounded-full bg-white/10 border border-white/10" />
+              <Image
+                src={m.image}
+                alt={`Portrait of ${m.name}`}
+                width={96}
+                height={96}
+                className="h-24 w-24 rounded-full object-cover"
+              />
               <div className="mt-3 text-white font-medium">{m.name}</div>
-              <div className="text-white/70 text-sm">{m.role}</div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- remove role labels from team page
- display placeholder images for each member
- type team member data and add descriptive alt text
- remove placeholder binary images from repository

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `next: not found` due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6258c100832ba623faf64d682614