### PR TITLE
chore: remove framer-motion to fix React peer conflict

### DIFF
--- a/components/AnimatedGradient.tsx
+++ b/components/AnimatedGradient.tsx
@@ -1,19 +1,23 @@
 "use client";
-import { motion } from "framer-motion";
 import React from "react";
 
+// Replaces the previous framer-motion animation with a CSS keyframe-based
+// animation so that we no longer depend on the framer-motion library.
 export function AnimatedGradient(){
   return (
     <div className="absolute inset-0 -z-10 overflow-hidden">
-      <motion.div
-        initial={{opacity: 0.3, scale: 0.9, x: -100, y: -100}}
-        animate={{opacity: 0.6, scale: 1, x: 0, y: 0}}
-        transition={{duration: 3, ease: "easeOut"}}
-      >
-        <div className="pointer-events-none blur-3xl">
-          <div className="h-[60vh] w-[80vw] md:w-[60vw] rounded-full from-brand-400 via-violet-500 to-emerald-400 bg-gradient-to-tr opacity-20" />
-        </div>
-      </motion.div>
+      <div className="pointer-events-none blur-3xl animate-gradient">
+        <div className="h-[60vh] w-[80vw] md:w-[60vw] rounded-full from-brand-400 via-violet-500 to-emerald-400 bg-gradient-to-tr opacity-20" />
+      </div>
+      <style jsx>{`
+        @keyframes gradientFade {
+          from { opacity: 0.3; transform: scale(0.9) translate(-100px, -100px); }
+          to { opacity: 0.6; transform: scale(1) translate(0, 0); }
+        }
+        .animate-gradient {
+          animation: gradientFade 3s ease-out forwards;
+        }
+      `}</style>
     </div>
   );
 }

--- a/components/Marquee.tsx
+++ b/components/Marquee.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { ORGS } from "@/lib/utils";
-import { motion, useAnimationFrame } from "framer-motion";
+// Removed dependency on framer-motion which caused installation issues.
 
 export default function Marquee(){
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "clsx": "2.1.1",
-        "framer-motion": "11.3.30",
         "lucide-react": "0.453.0",
         "next": "15.5.0",
         "react": "19.0.0",
@@ -3116,31 +3115,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/framer-motion": {
-      "version": "11.3.30",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.30.tgz",
-      "integrity": "sha512-9VmqGe9OIjfMoCcs+ZsKXlv6JaG5QagKX2F1uSbkG3Z33wgjnz60Kw+CngC1M49rDYau+Y9aL+8jGagAwrbVyw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "clsx": "2.1.1",
     "critters": "0.0.22",
-    "framer-motion": "11.3.30",
     "lucide-react": "0.453.0",
     "next": "15.5.0",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- remove `framer-motion` dependency causing React 19 peer conflict
- replace animated gradient with a CSS keyframe animation
- drop unused framer-motion import in Marquee component

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/critters)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf976c69f0832bb59c13e6e2f1d4c6