### PR TITLE
fix: restore street quality criteria constant

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -4,6 +4,7 @@ import VideoPlayer from "@/components/VideoPlayer";
 import Marquee from "@/components/Marquee";
 import FeatureCard from "@/components/FeatureCard";
 import Steps from "@/components/Steps";
+import { STREET_QUALITY_CRITERIA } from "@/lib/utils";
 
 export default function Page(){
   return (

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,12 @@ export const ORGS = [
   "Congolese Community Center of Montreal"
 ];
 
+export const STREET_QUALITY_CRITERIA = [
+  "Accessibility","Invitingness","Comfort","Regeneration","Aesthetics",
+  "Practicality","Maintenance","Inclusivity","Dynamism","Representation",
+  "Oppression","Security",
+];
+
 export const SITE_NAME = "WeDesign+";
 export const DOMAIN = "wedesign.one";
 export const TAGLINE = "Designing inclusive public spaces through participatory AI";


### PR DESCRIPTION
## Summary
- restore `STREET_QUALITY_CRITERIA` constant in utils
- import and use street quality criteria on home page

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/critters)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/critters)*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9a0abbe4832b8bb59e0cfd89df6d