### PR TITLE
Remove Vercel reference from footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,7 +28,7 @@ export function Footer(){
         </div>
         <div className="text-white/60">
           <p>&copy; {new Date().getFullYear()} WeDesign+. All rights reserved.</p>
-          <p className="mt-1">Built for Vercel • Montreal, Canada</p>
+          <p className="mt-1">Montreal, Canada</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- remove "Built for Vercel" from footer text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found; unable to install deps `npm ci` due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa2c51fcc832baa43e5312a120843