### PR TITLE
feat: improve navigation accessibility and logo

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,8 +38,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={inter.variable}>
       <body className="min-h-dvh">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:p-2 focus:bg-black focus:text-white focus:rounded"
+        >
+          Skip to content
+        </a>
         <Header />
-        <main>{children}</main>
+        <main id="main-content">{children}</main>
         <Footer />
       </body>
     </html>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -26,7 +26,7 @@ export function Header(){
               <Logo />
               <span className="font-semibold tracking-tight text-white">WeDesign<span className="text-white/60">+</span></span>
             </Link>
-            <nav className="hidden md:flex items-center gap-1">
+            <nav className="hidden md:flex items-center gap-1" aria-label="Primary">
               {NAV.map(item => (
                 <Link
                   key={item.href}
@@ -51,13 +51,15 @@ export function Header(){
                 className="md:hidden px-3 py-2 rounded-lg bg-white/10"
                 onClick={() => setOpen(!open)}
                 aria-label="Toggle menu"
+                aria-expanded={open}
+                aria-controls="mobile-menu"
               >
                 {open ? "✕" : "☰"}
               </button>
             </div>
           </div>
           {open && (
-            <nav className="md:hidden px-4 pb-4 flex flex-col gap-1">
+            <nav id="mobile-menu" className="md:hidden px-4 pb-4 flex flex-col gap-1" aria-label="Mobile">
               {NAV.map(item => (
                 <Link
                   key={item.href}

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -3,11 +3,12 @@ import React from "react";
 export function Logo({className}:{className?:string}){
   return (
     <div className={className}>
-      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <rect x="1" y="1" width="26" height="26" rx="6" className="stroke-white/40" strokeWidth="2" fill="url(#g)"/>
         <defs>
           <radialGradient id="g" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(4 4) rotate(45) scale(24 24)">
-            <stop stopColor="#60A5FA" stopOpacity="0.6"/>
+            <stop offset="0" stopColor="#60A5FA" stopOpacity="0.6"/>
+            <stop offset="0.7" stopColor="#34D399" stopOpacity="0.4"/>
             <stop offset="1" stopColor="transparent"/>
           </radialGradient>
         </defs>


### PR DESCRIPTION
## Summary
- add skip-to-content link for better keyboard navigation
- enhance header menu accessibility with aria attributes
- refresh logo gradient and mark as decorative SVG

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/critters)


------
https://chatgpt.com/codex/tasks/task_e_68bfa28bdbe0832b9cb1dc29848f907c